### PR TITLE
Include lib jars to maven classpath.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,16 @@
 				</configuration>
 			</plugin>
 			<plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-compiler-plugin</artifactId>
+                <version>1.0.0</version>
+                <configuration>
+                    <includes>
+                        <include>${baseDir}/org.sf.feeling.decompiler/lib/*.jar</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-maven-plugin</artifactId>
 				<version>1.0.0</version>


### PR DESCRIPTION
Here is a small fix so long, to allow maven build.

By including  `org.sf.feeling.decompiler/lib/*.jar` to the compiler class path we are now able to successfully build with maven.