### PR TITLE
NotWorking: Attempt at navigatoreContent extension

### DIFF
--- a/org.sf.feeling.decompiler/plugin.properties
+++ b/org.sf.feeling.decompiler/plugin.properties
@@ -21,3 +21,4 @@ Decompiler.Filter.Description=Hides the Eclipse decompiler temporary project.
 Decompiler.Filter=Eclipse decompiler temporary project
 Opcode.Hover.Lable=JVM Opcode Doc
 Opcode.Hover.Description=Shows the document of the selected JVM opcode element.
+NavigatorContent=Java Archive

--- a/org.sf.feeling.decompiler/plugin.xml
+++ b/org.sf.feeling.decompiler/plugin.xml
@@ -16,6 +16,7 @@
             name="%DecompilerView"
             icon="icons/decompiler.png"
             extensions="class"
+            default="true"
             class="org.sf.feeling.decompiler.editor.JavaDecompilerClassFileEditor"
             contributorClass="org.eclipse.jdt.internal.ui.javaeditor.ClassFileEditorActionContributor"
             id="org.sf.feeling.decompiler.ClassFileEditor"
@@ -357,5 +358,27 @@
    </extension>
    <extension point="org.eclipse.help.toc">
     <toc file="doc/toc.xml" primary="true" />
-  </extension>	 
+  </extension>
+   <extension
+         point="org.eclipse.ui.navigator.navigatorContent">
+      <navigatorContent
+            activeByDefault="true"
+            contentProvider="org.sf.feeling.decompiler.JarContentProvider"
+            id="org.sf.feeling.decompiler.navigatorContent"
+            labelProvider="org.sf.feeling.decompiler.JarLabelProvider"
+            name="%NavigatorContent">
+         <triggerPoints>
+            <or>
+               <instanceof value="org.eclipse.core.resources.IFile" />
+               <instanceof value="org.sf.feeling.decompiler.JarContentProvider.JarNode" />
+            </or>
+         </triggerPoints>
+         <possibleChildren>
+            <or>
+               <instanceof value="org.sf.feeling.decompiler.JarContentProvider.JarNode" />
+               <instanceof value="org.eclipse.core.resources.IFile" />
+            </or>
+         </possibleChildren>
+      </navigatorContent>
+   </extension>
 </plugin>

--- a/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/JarContentProvider.java
+++ b/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/JarContentProvider.java
@@ -1,0 +1,115 @@
+package org.sf.feeling.decompiler;
+
+import java.io.File;
+import java.net.JarURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.ui.model.BaseWorkbenchContentProvider;
+
+
+
+public class JarContentProvider extends BaseWorkbenchContentProvider
+{
+	private static final String[] types = {"jar", "war"};
+	public class JarNode
+	{
+		private final URL url;
+		private final URL parent;
+		private final JarEntry entry;
+
+		public JarNode(URI jarfile, JarEntry entry) throws MalformedURLException {
+			this.url = new URL(String.format("jar:%s!/%s", jarfile, entry));
+			this.parent = new URL(String.format("jar:%s!/%s", jarfile,
+					entry.getName().substring(0, entry.getName()
+							.replaceAll("/$","").lastIndexOf("/")+1)));
+			this.entry = entry;
+		}
+		public JarNode(URL url, JarEntry entry) throws MalformedURLException {
+			this.url = url;
+			this.parent = new URL(url.toString( ).substring(0,
+					url.toString( ).replaceAll("/$","").lastIndexOf("/")+1));
+			this.entry = entry;
+		}
+
+		public URL toURL() {
+			return url;
+		}
+
+		public URL getParent() {
+			return parent;
+		}
+
+		public JarEntry getEntry() {
+			return entry;
+		}
+	}
+
+	private final Map<URL,List<JarNode>> nodes = new HashMap<>();
+	private final Map<String,IFile> files = new HashMap<>( );
+
+	private boolean isJavaArchive(IFile file) {
+//		return Arrays.binarySearch( types, file.getFileExtension() ) >= 0;
+		return true;
+	}
+
+	@Override
+	public Object[] getChildren( Object parentElement )
+	{
+		if ( parentElement instanceof IFile && isJavaArchive( (IFile) parentElement ) ) {
+			File f = ((IFile) parentElement).getLocation( ).toFile( );
+			try ( JarFile jf = new JarFile( f ) ) {
+				files.put( f.toURI( )+"!/", (IFile) parentElement );
+				for ( JarEntry je:Collections.list( jf.entries( ) ) ) {
+					JarNode node = new JarNode(f.toURI( ), je);
+					if (!nodes.containsKey( node.getParent( ) ))
+						nodes.put( node.getParent( ), new ArrayList<JarNode>( ) );
+					nodes.get( node.getParent( ) ).add( node );
+				}
+				return nodes.get( new URL( String.format( "jar:%s!/", f.toURI( ) ) ) ).toArray( );
+			} catch (Throwable t) {};
+		}
+		if (parentElement instanceof JarNode && ((JarNode) parentElement).getEntry( ).isDirectory( ))
+			return nodes.get( ((JarNode) parentElement).toURL( ) ).toArray( );
+		return new Object[0];
+	}
+
+	@Override
+	public Object getParent( Object element )
+	{
+		if (element instanceof JarNode) {
+			JarNode node = (JarNode) element;
+			try
+			{
+				return new JarNode(node.getParent( ),
+						((JarURLConnection) node.getParent( ).openConnection( )).getJarEntry( ));
+			} catch ( Throwable t ) {
+				try
+				{
+					return files.get( node.getParent( ).toURI( ).getSchemeSpecificPart( ) );
+				} catch ( URISyntaxException e ) {}
+			}
+		}
+		return super.getParent( element );
+	}
+
+	@Override
+	public boolean hasChildren( Object element )
+	{
+		if (element instanceof JarNode)
+			return nodes.containsKey( ((JarNode) element).toURL( ) );
+		return super.hasChildren( element );
+	}
+
+}

--- a/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/JarLabelProvider.java
+++ b/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/JarLabelProvider.java
@@ -1,0 +1,20 @@
+package org.sf.feeling.decompiler;
+
+import org.eclipse.jface.viewers.LabelProvider;
+
+
+public class JarLabelProvider extends LabelProvider
+{
+	@Override
+	public String getText(Object element) {
+		if (null == element)
+			return "";
+		if (element instanceof JarContentProvider.JarNode) {
+			String n = ((JarContentProvider.JarNode) element)
+					.getEntry( ).getName( ).replaceAll( "/$", "" );
+			return n.substring( n.lastIndexOf( '/' ), n.length( ) );
+		}
+		return element.toString();
+	}
+
+}


### PR DESCRIPTION
As per issues #25 I attempted to create a `navigatorContent` extension for browsing jar files.

The implementation is not perfect but it should at least do something. If nothing else I would've been pleased with some sort of exception but nada...

Not sure what to try next?!?!?

I included the an attribute I found to set the decompiler association by default, this does seem to work but it could also just be cache that is allowing this to association to be set, again I cannot be sure.

Submitting this for fresh eyes who may be able to spot something I may have done wrong or something that I missing as I cannot think of anything else to try. It simply does nothing. 

