### PR TITLE
Fix mapSource invocation

### DIFF
--- a/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/editor/BaseDecompilerSourceMapper.java
+++ b/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/editor/BaseDecompilerSourceMapper.java
@@ -36,6 +36,7 @@ import org.sf.feeling.decompiler.util.ClassUtil;
 import org.sf.feeling.decompiler.util.DecompileUtil;
 import org.sf.feeling.decompiler.util.DecompilerOutputUtil;
 import org.sf.feeling.decompiler.util.Logger;
+import org.sf.feeling.decompiler.util.SourceMapperUtil;
 import org.sf.feeling.decompiler.util.ReflectionUtils;
 import org.sf.feeling.decompiler.util.SortMemberUtil;
 import org.sf.feeling.decompiler.util.UIUtil;
@@ -96,7 +97,7 @@ public abstract class BaseDecompilerSourceMapper extends DecompilerSourceMapper
 				updateSourceRanges( type, attachedSource );
 				isAttachedSource = true;
 				mapSourceSwitch( type, attachedSource, true );
-				DecompileUtil.mapSource( ( (PackageFragmentRoot) root ).getSourceMapper( ), type, attachedSource, info );
+				SourceMapperUtil.mapSource( ( (PackageFragmentRoot) root ).getSourceMapper( ), type, attachedSource, info );
 				return attachedSource;
 			}
 		}
@@ -132,7 +133,7 @@ public abstract class BaseDecompilerSourceMapper extends DecompilerSourceMapper
 						updateSourceRanges( type, attachedSource );
 						isAttachedSource = true;
 						mapSourceSwitch( type, attachedSource, true );
-						DecompileUtil.mapSource( ( (PackageFragmentRoot) root ).getSourceMapper( ), type, attachedSource, info );
+						SourceMapperUtil.mapSource( ( (PackageFragmentRoot) root ).getSourceMapper( ), type, attachedSource, info );
 						return attachedSource;
 					}
 				}
@@ -239,7 +240,7 @@ public abstract class BaseDecompilerSourceMapper extends DecompilerSourceMapper
 			SourceMapper rootSourceMapper = originalSourceMapper.get( root );
 			if ( rootSourceMapper.findSource( type, info ) == null )
 			{
-				DecompileUtil.mapSource( rootSourceMapper, type, sourceAsCharArray, info );
+				SourceMapperUtil.mapSource( rootSourceMapper, type, sourceAsCharArray, info );
 			}
 		}
 

--- a/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/editor/ClassFileSourceMap.java
+++ b/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/editor/ClassFileSourceMap.java
@@ -19,6 +19,7 @@ import org.eclipse.jdt.internal.core.BufferManager;
 import org.eclipse.jdt.internal.core.ClassFile;
 import org.eclipse.jdt.internal.core.SourceMapper;
 import org.sf.feeling.decompiler.util.DecompileUtil;
+import org.sf.feeling.decompiler.util.SourceMapperUtil;
 
 public class ClassFileSourceMap
 {
@@ -61,7 +62,7 @@ public class ClassFileSourceMap
 			// buffer.addBufferChangedListener( cf );
 
 			// do the source mapping
-			DecompileUtil.mapSource( mapper, getOuterMostEnclosingType( cf ), contents, info );
+			SourceMapperUtil.mapSource( mapper, getOuterMostEnclosingType( cf ), contents, info );
 
 			return;
 		}

--- a/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/editor/DecompilerSourceMapper.java
+++ b/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/editor/DecompilerSourceMapper.java
@@ -9,15 +9,12 @@
 package org.sf.feeling.decompiler.editor;
 
 import java.io.File;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Plugin;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IParent;
@@ -29,7 +26,6 @@ import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.core.BinaryType;
-import org.eclipse.jdt.internal.core.NamedMember;
 import org.eclipse.jdt.internal.core.SourceMapper;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.BadLocationException;
@@ -38,7 +34,7 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.text.edits.TextEdit;
 import org.sf.feeling.decompiler.JavaDecompilerPlugin;
 import org.sf.feeling.decompiler.util.DecompilerOutputUtil;
-import org.sf.feeling.decompiler.util.ReflectionUtils;
+import org.sf.feeling.decompiler.util.SourceMapperUtil;
 
 public abstract class DecompilerSourceMapper extends SourceMapper
 {
@@ -91,19 +87,9 @@ public abstract class DecompilerSourceMapper extends SourceMapper
 			sourceRanges.remove( type );
 		}
 		
+		
 		try {
-			Method mapSource = getClass( ).getMethod(
-					"mapSource",
-					new Class[] { IType.class, char[].class, IBinaryType.class } );
-			
-			mapSource.invoke( this, new Object[] { type, contents, null} );
-		} catch (NoSuchMethodException e) {
-			// API changed with Java 9 support (#daa227e4f5b7af888572a286c4f973b7a167ff2e)
-			ReflectionUtils.invokeMethod( this, "mapSource", new Class[]{ //$NON-NLS-1$
-					NamedMember.class, char[].class, IBinaryType.class
-			}, new Object[]{
-					type, contents, null
-			} );
+			SourceMapperUtil.mapSource( this, type, contents, null );
 		} catch (Exception e) {
 			// Method was found but invocation failed, this shouldn't happen.
 		}

--- a/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/editor/ImportSourceMapper.java
+++ b/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/editor/ImportSourceMapper.java
@@ -26,7 +26,6 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
-import org.eclipse.jdt.internal.core.BinaryType;
 import org.eclipse.jdt.internal.core.ClassFile;
 import org.eclipse.jdt.internal.core.ImportContainer;
 import org.eclipse.jdt.internal.core.ImportContainerInfo;
@@ -34,7 +33,6 @@ import org.eclipse.jdt.internal.core.ImportDeclaration;
 import org.eclipse.jdt.internal.core.ImportDeclarationElementInfo;
 import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.jdt.internal.core.JavaModelManager;
-import org.eclipse.jdt.internal.core.NamedMember;
 import org.eclipse.jdt.internal.core.OpenableElementInfo;
 import org.eclipse.jdt.internal.core.SourceMapper;
 import org.sf.feeling.decompiler.util.DecompilerOutputUtil;
@@ -107,7 +105,7 @@ public class ImportSourceMapper extends SourceMapper
 		}
 
 		try {
-			SourceMapperUtil.mapSource( this, type, contents, info );
+			SourceMapperUtil.mapSource( this, type, contents, info, elementToFind );
 		} catch (Exception e) {
 			// Method was found but invocation failed, this shouldn't happen.
 		}

--- a/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/editor/ImportSourceMapper.java
+++ b/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/editor/ImportSourceMapper.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.internal.core.OpenableElementInfo;
 import org.eclipse.jdt.internal.core.SourceMapper;
 import org.sf.feeling.decompiler.util.DecompilerOutputUtil;
 import org.sf.feeling.decompiler.util.Logger;
+import org.sf.feeling.decompiler.util.SourceMapperUtil;
 import org.sf.feeling.decompiler.util.ReflectionUtils;
 
 public class ImportSourceMapper extends SourceMapper
@@ -106,18 +107,7 @@ public class ImportSourceMapper extends SourceMapper
 		}
 
 		try {
-			Method mapSource = getClass( ).getMethod(
-					"mapSource",
-					new Class[] { IType.class, char[].class, IBinaryType.class, IJavaElement.class } );
-			
-			return (ISourceRange) mapSource.invoke( this, new Object[] { type, contents, info, elementToFind } );
-		} catch (NoSuchMethodException e) {
-			// API changed with Java 9 support (#daa227e4f5b7af888572a286c4f973b7a167ff2e)
-			return (ISourceRange) ReflectionUtils.invokeMethod( this, "mapSource", new Class[]{ //$NON-NLS-1$
-					NamedMember.class, char[].class, IBinaryType.class, IJavaElement.class
-			}, new Object[]{
-					type, contents, info, elementToFind
-			} );
+			SourceMapperUtil.mapSource( this, type, contents, info );
 		} catch (Exception e) {
 			// Method was found but invocation failed, this shouldn't happen.
 		}

--- a/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/util/DecompileUtil.java
+++ b/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/util/DecompileUtil.java
@@ -22,7 +22,6 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.core.ClassFile;
-import org.eclipse.jdt.internal.core.NamedMember;
 import org.eclipse.jdt.internal.core.SourceMapper;
 import org.eclipse.ui.ide.FileStoreEditorInput;
 import org.sf.feeling.decompiler.editor.DecompilerSourceMapper;
@@ -105,7 +104,7 @@ public class DecompileUtil
 					new Object[0] );
 			HashMap sourceRange = (HashMap) ReflectionUtils.getFieldValue( mapper, "sourceRanges" ); //$NON-NLS-1$
 			sourceRange.remove( type );
-			DecompileUtil.mapSource( mapper, type, contents.toCharArray( ), typeInfo );
+			SourceMapperUtil.mapSource( mapper, type, contents.toCharArray( ), typeInfo );
 
 			// List rootPaths = (List) ReflectionUtils.getFieldValue( mapper,
 			// "rootPaths" );
@@ -168,23 +167,5 @@ public class DecompileUtil
 			return buffer.toString( );
 		}
 		return null;
-	}
-	
-	public static void mapSource(SourceMapper sourceMapper, IType type, char[] source, IBinaryType info)
-	{
-		try {
-			ReflectionUtils.invokeMethod( sourceMapper, "mapSource", new Class[]{ //$NON-NLS-1$
-					IType.class, char[].class, IBinaryType.class 
-			}, new Object[]{
-					type, source, info
-			} );
-		} catch (final NoSuchMethodError e) {
-			// API changed with Java 9 support (#daa227e4f5b7af888572a286c4f973b7a167ff2e)
-			ReflectionUtils.invokeMethod( sourceMapper, "mapSourceSwitch", new Class[]{ //$NON-NLS-1$
-					NamedMember.class, char[].class, IBinaryType.class
-			}, new Object[]{
-					type, source, info
-			} );
-		}
 	}
 }

--- a/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/util/ReflectionUtils.java
+++ b/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/util/ReflectionUtils.java
@@ -62,6 +62,11 @@ public class ReflectionUtils
 			return null;
 
 		Method method = getDeclaredMethod( object, methodName, parameterTypes );
+		return invokeMethod(method, object, parameters);
+	}
+
+	public static Object invokeMethod( Method method, Object object, Object[] parameters )
+	{
 		try
 		{
 			if ( null != method )

--- a/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/util/SourceMapperUtil.java
+++ b/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/util/SourceMapperUtil.java
@@ -2,6 +2,7 @@ package org.sf.feeling.decompiler.util;
 
 import java.lang.reflect.Method;
 
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.core.NamedMember;
@@ -13,6 +14,10 @@ public class SourceMapperUtil
 
 	public static void mapSource(SourceMapper sourceMapper, IType type, char[] source, IBinaryType info)
 	{
+		mapSource(sourceMapper, type, source, info, null);
+	}
+	
+	public static void mapSource(SourceMapper sourceMapper, IType type, char[] source, IBinaryType info, IJavaElement elementToFind) {
 		Method mapSourceMethod = getMapSourceMethod( sourceMapper );
 
 		// API changed with Java 9 support (#daa227e4f5b7af888572a286c4f973b7a167ff2e)
@@ -21,24 +26,24 @@ public class SourceMapperUtil
 		}
 		
 		if (mapSourceMethod != null) {
-			Object[] parameters = new Object[] { type, source, info };
+			Object[] parameters = new Object[] { type, source, info, elementToFind };
 			ReflectionUtils.invokeMethod( mapSourceMethod, sourceMapper, parameters );
 		} else {
-			throw new IllegalStateException( "Unable to invoke mapSource method on sourceMapper" );
+			throw new IllegalStateException( "Unable to invoke mapSource method on sourceMapper" ); //$NON-NLS-1$
 		}
 	}
 
 	private static Method getMapSourceMethod( SourceMapper sourceMapper )
 	{
 		return ReflectionUtils.getDeclaredMethod( sourceMapper, MAP_SOURCE_METHOD_NAME, new Class[]{
-				NamedMember.class, char[].class, IBinaryType.class
+				NamedMember.class, char[].class, IBinaryType.class, IJavaElement.class
 		});
 	}
 
 	private static Method getLegacyMapSourceMethod( SourceMapper sourceMapper )
 	{
 		return ReflectionUtils.getDeclaredMethod( sourceMapper, MAP_SOURCE_METHOD_NAME, new Class[]{
-				IType.class, char[].class, IBinaryType.class
+				IType.class, char[].class, IBinaryType.class, IJavaElement.class
 		});
 	}
 }

--- a/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/util/SourceMapperUtil.java
+++ b/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/util/SourceMapperUtil.java
@@ -1,0 +1,44 @@
+package org.sf.feeling.decompiler.util;
+
+import java.lang.reflect.Method;
+
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.internal.compiler.env.IBinaryType;
+import org.eclipse.jdt.internal.core.NamedMember;
+import org.eclipse.jdt.internal.core.SourceMapper;
+
+public class SourceMapperUtil
+{
+	private static final String MAP_SOURCE_METHOD_NAME = "mapSource"; //$NON-NLS-1$
+
+	public static void mapSource(SourceMapper sourceMapper, IType type, char[] source, IBinaryType info)
+	{
+		Method mapSourceMethod = getMapSourceMethod( sourceMapper );
+
+		// API changed with Java 9 support (#daa227e4f5b7af888572a286c4f973b7a167ff2e)
+		if (mapSourceMethod == null) {
+			mapSourceMethod = getLegacyMapSourceMethod( sourceMapper );
+		}
+		
+		if (mapSourceMethod != null) {
+			Object[] parameters = new Object[] { type, source, info };
+			ReflectionUtils.invokeMethod( mapSourceMethod, sourceMapper, parameters );
+		} else {
+			throw new IllegalStateException( "Unable to invoke mapSource method on sourceMapper" );
+		}
+	}
+
+	private static Method getMapSourceMethod( SourceMapper sourceMapper )
+	{
+		return ReflectionUtils.getDeclaredMethod( sourceMapper, MAP_SOURCE_METHOD_NAME, new Class[]{
+				NamedMember.class, char[].class, IBinaryType.class
+		});
+	}
+
+	private static Method getLegacyMapSourceMethod( SourceMapper sourceMapper )
+	{
+		return ReflectionUtils.getDeclaredMethod( sourceMapper, MAP_SOURCE_METHOD_NAME, new Class[]{
+				IType.class, char[].class, IBinaryType.class
+		});
+	}
+}


### PR DESCRIPTION
PR for #44 
## What
 - Moved out the mapSource to a central util to avoid code duplication
 - Queried the method before calling it instead of relying on exceptions
 - Added fail fast in case of the correct method is not found to ease later debugging efforts
 - In JDT there is two overloaded methods with this name, but they are telescopic, and just pass null if the additional parameter are not filled. I followed the same principle to simplify the code.

## Why 
mapSource signature was changed in Eclipse Photon, however the invocation was still calling with the previous signature and did not fallback to the correct signature. This caused at least that: breakpoints cannot be set in decompiled classes, info is not shown for variables in decompiled class.


Please review, also let me know, if there are tests somewhere, which I have missed.