### PR TITLE
Add support for classes in JRT

### DIFF
--- a/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/util/JarClassExtractor.java
+++ b/org.sf.feeling.decompiler/src/org/sf/feeling/decompiler/util/JarClassExtractor.java
@@ -33,13 +33,26 @@ public class JarClassExtractor
 	public static void extract( String archivePath, String packege, String className, boolean inner, String to )
 			throws IOException
 	{
-		if ( archivePath.endsWith( JRTUtil.JRT_FS_JAR ) )
+		if ( isClassInJrt( archivePath ) )
 		{
 			extractClassFromJrt( archivePath, packege, className, to );
 		}
 		else
 		{
 			extractClassesFromJar( archivePath, packege, className, inner, to );
+		}
+	}
+
+	private static boolean isClassInJrt( String archivePath )
+	{
+		try
+		{
+			return archivePath.endsWith( JRTUtil.JRT_FS_JAR );
+		}
+		catch ( NoClassDefFoundError e )
+		{
+			// Compatible with pre-Oxygen Eclipse, where JRTUtil does not exist
+			return false;
 		}
 	}
 
@@ -57,7 +70,6 @@ public class JarClassExtractor
 		}
 		catch ( ClassFormatException e )
 		{
-			e.printStackTrace( );
 			throw new RuntimeException( "Unable to read JRT file", e );
 		}
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -103,9 +103,9 @@
 
 	<repositories>
 		<repository>
-			<id>eclipse-juno</id>
+			<id>eclipse-oxygen</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/juno</url>
+			<url>http://download.eclipse.org/releases/oxygen</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
# What
 - When the class is located in the JRT filesystem, extract content from there, instead of treating it as a jar

# Why
 - Java 9 no longer contains it's class files in JAR files like previous versions, it now uses a modules file. https://openjdk.java.net/jeps/220
 - So trying to load a JDK class from jar it will fail to decompile. Most JDK classes have source in the JDK src.zip, so it won't affect those

# How
 - Similarly to how Eclipse does [internally](https://github.com/eclipse/eclipse.jdt.core/blob/master/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarEntryFile.java#L54)

# Notes
 - JRTUtil was introduced in Eclipse Oxygen, so I had to raise the version.
However this should not limit the installability of the plugin, because the jdt versions are not fixed in MANIFEST file. I have added an additional catch, so earlier versions of Eclipse will not fail with ClassDefNotFound exception.
When the baseline of the plugin is incremented, that try-catch can be removed